### PR TITLE
feat: manage management.server.port 

### DIFF
--- a/charts/better-spring-boot/README.md
+++ b/charts/better-spring-boot/README.md
@@ -66,6 +66,7 @@ The following spring configuration is manged by the helm chart.
 
 | Spring boot                      | Chart                                                        |
 |----------------------------------|--------------------------------------------------------------|
+| management.server.port           | spring.managementPort                                        |
 | server.port                      | spring.serverPort                                            |
 | spring.application.name          | spring.applicationName                                       |
 | spring.profiles.active           | [profile management](#easy-profile-configuration-management) |

--- a/charts/better-spring-boot/templates/_helpers_deployment.yaml
+++ b/charts/better-spring-boot/templates/_helpers_deployment.yaml
@@ -30,10 +30,11 @@ release/roll-me: {{ print .Release.Revision "-" (randAlphaNum 5) | quote }}
 {{- define "better-spring-boot.deployment.containerEnv" }}
   {{- $envVars := .Values.spring.environmentVariable }}
   {{- $envVars = omit $envVars
-        "SPRING_PROFILES_ACTIVE"
-        "SPRING_CONFIG_ADDITIONAL_LOCATION"
-        "SPRING_APPLICATION_NAME"
+        "MANAGEMENT_SERVER_PORT"
         "SERVER_PORT"
+        "SPRING_APPLICATION_NAME"
+        "SPRING_CONFIG_ADDITIONAL_LOCATION"
+        "SPRING_PROFILES_ACTIVE"
   }}
   {{- range $key, $value := $envVars }}
   {{- if ne $value nil }}
@@ -53,10 +54,18 @@ release/roll-me: {{ print .Release.Revision "-" (randAlphaNum 5) | quote }}
 - name: SPRING_CONFIG_ADDITIONAL_LOCATION
   value: optional:/app/config/*/
 - name: SERVER_PORT
-  value: {{ .Values.spring.serverPort | default .Values.service.port | toString | toJson }}
+  value: {{ include "better-spring-boot.deployment.applicationServerPort" . | toString | toJson }}
+- name: MANAGEMENT_SERVER_PORT
+  value: {{ include "better-spring-boot.deployment.managementServerPort" . | toString | toJson }}
 {{- end }}
 
+{{- define "better-spring-boot.deployment.applicationServerPort" }}
+{{- .Values.spring.serverPort | default .Values.service.port }}
+{{- end }}
 
+{{- define "better-spring-boot.deployment.managementServerPort" }}
+{{- .Values.spring.managementPort | default (include "better-spring-boot.deployment.applicationServerPort" .) }}
+{{- end }}
 
 {{- define "better-spring-boot.deployment.appHealthChecks" }}
 {{- if and .Values.debugDeployment.enabled (not .Values.debugDeployment.healthChecksEnabled) }}

--- a/charts/better-spring-boot/templates/deployment.yaml
+++ b/charts/better-spring-boot/templates/deployment.yaml
@@ -47,10 +47,10 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: {{ .Values.spring.serverPort | default .Values.service.port }}
+              containerPort: {{ include "better-spring-boot.deployment.applicationServerPort" . }}
               protocol: TCP
             - name: http-management
-              containerPort: {{ .Values.spring.managementPort | default .Values.spring.serverPort | default .Values.service.port }}
+              containerPort: {{ include "better-spring-boot.deployment.managementServerPort" . }}
               protocol: TCP
           {{- include "better-spring-boot.deployment.appHealthChecks" . | nindent 10 }}
           resources:

--- a/charts/better-spring-boot/tests/__snapshot__/applicationYaml_test.yaml.snap
+++ b/charts/better-spring-boot/tests/__snapshot__/applicationYaml_test.yaml.snap
@@ -10,6 +10,8 @@ injects application properties spring-container:
             value: optional:/app/config/*/
           - name: SERVER_PORT
             value: "8080"
+          - name: MANAGEMENT_SERVER_PORT
+            value: "8080"
         image: goatfryed/spring-boot-echo:latest
         imagePullPolicy: IfNotPresent
         name: spring-boot
@@ -72,6 +74,8 @@ mounts configuration values:
             value: optional:/app/config/*/
           - name: SERVER_PORT
             value: "8080"
+          - name: MANAGEMENT_SERVER_PORT
+            value: "8080"
         image: goatfryed/spring-boot-echo:latest
         imagePullPolicy: IfNotPresent
         name: spring-boot
@@ -105,6 +109,8 @@ mounts referenced configMaps:
           - name: SPRING_CONFIG_ADDITIONAL_LOCATION
             value: optional:/app/config/*/
           - name: SERVER_PORT
+            value: "8080"
+          - name: MANAGEMENT_SERVER_PORT
             value: "8080"
         image: goatfryed/spring-boot-echo:latest
         imagePullPolicy: IfNotPresent
@@ -146,6 +152,8 @@ mounts referenced secrets:
           - name: SPRING_CONFIG_ADDITIONAL_LOCATION
             value: optional:/app/config/*/
           - name: SERVER_PORT
+            value: "8080"
+          - name: MANAGEMENT_SERVER_PORT
             value: "8080"
         image: goatfryed/spring-boot-echo:latest
         imagePullPolicy: IfNotPresent

--- a/charts/better-spring-boot/tests/__snapshot__/chart_test.yaml.snap
+++ b/charts/better-spring-boot/tests/__snapshot__/chart_test.yaml.snap
@@ -76,6 +76,8 @@ works with maximal configuration:
                   value: optional:/app/config/*/
                 - name: SERVER_PORT
                   value: "8083"
+                - name: MANAGEMENT_SERVER_PORT
+                  value: "8090"
               image: user-registry/user-repo:user-tag
               imagePullPolicy: Always
               livenessProbe:
@@ -326,6 +328,8 @@ works with minimal configuration:
                 - name: SPRING_CONFIG_ADDITIONAL_LOCATION
                   value: optional:/app/config/*/
                 - name: SERVER_PORT
+                  value: "8080"
+                - name: MANAGEMENT_SERVER_PORT
                   value: "8080"
               image: goatfryed/spring-boot-echo:latest
               imagePullPolicy: IfNotPresent

--- a/charts/better-spring-boot/tests/__snapshot__/debugMode_test.yaml.snap
+++ b/charts/better-spring-boot/tests/__snapshot__/debugMode_test.yaml.snap
@@ -12,6 +12,8 @@ adds health checks only if explicitly activated:
             value: optional:/app/config/*/
           - name: SERVER_PORT
             value: "8080"
+          - name: MANAGEMENT_SERVER_PORT
+            value: "8080"
         image: goatfryed/spring-boot-echo:latest
         imagePullPolicy: IfNotPresent
         name: spring-boot
@@ -45,6 +47,8 @@ overrides profiles:
           - name: SPRING_CONFIG_ADDITIONAL_LOCATION
             value: optional:/app/config/*/
           - name: SERVER_PORT
+            value: "8080"
+          - name: MANAGEMENT_SERVER_PORT
             value: "8080"
         image: goatfryed/spring-boot-echo:latest
         imagePullPolicy: IfNotPresent
@@ -81,6 +85,8 @@ overrides run command:
           - name: SPRING_CONFIG_ADDITIONAL_LOCATION
             value: optional:/app/config/*/
           - name: SERVER_PORT
+            value: "8080"
+          - name: MANAGEMENT_SERVER_PORT
             value: "8080"
         image: goatfryed/spring-boot-echo:latest
         imagePullPolicy: IfNotPresent

--- a/charts/better-spring-boot/tests/deployment_test.yaml
+++ b/charts/better-spring-boot/tests/deployment_test.yaml
@@ -275,6 +275,64 @@ tests:
           content:
             name: SERVER_PORT
             value: "8080"
+  - it: sets user provided server port
+    set:
+      spring.serverPort: 9191
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            containerPort: 9191
+            name: http
+            protocol: TCP
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SERVER_PORT
+            value: "9191"
+  - it: manages MANAGEMENT_SERVER_PORT
+    set:
+      spring.environmentVariable.MANAGEMENT_SERVER_PORT: "123"
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MANAGEMENT_SERVER_PORT
+            value: "123"
+  - it: sets management port
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            containerPort: 8080
+            name: http-management
+            protocol: TCP
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MANAGEMENT_SERVER_PORT
+            value: "8080"
+  - it: sets user provided management port
+    set:
+      spring.managementPort: 9191
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            containerPort: 9191
+            name: http-management
+            protocol: TCP
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MANAGEMENT_SERVER_PORT
+            value: "9191"
 
 
 

--- a/charts/better-spring-boot/values.yaml
+++ b/charts/better-spring-boot/values.yaml
@@ -18,7 +18,7 @@ spring:
   applicationName: ~
   # sets server.port and named port http, defaults to service.port
   serverPort: 8080
-  # if you configure management.server.port, set this to the same value
+  # sets server.port and named port http-management, defaults to spring.serverPort
   managementPort: ~
   profiles:
     # Configure your activated profiles here


### PR DESCRIPTION
As in #24, we take control and set MANAGEMENT_SERVER_PORT as configured in the helm chart to ensure kubernetes port configuration is aligned with spring server configuration